### PR TITLE
Fixed missing dash in git empty commit command for part 1a

### DIFF
--- a/src/content/1/en/part1a.md
+++ b/src/content/1/en/part1a.md
@@ -174,7 +174,7 @@ We'll use the empty commits to give us a non-standard way of leaving notes in ou
 Go to terminal and write this line.
 
 ```bash
-git commit -allow-empty -m "Practicing an empty commit while reading part 1a"
+git commit --allow-empty -m "Practicing an empty commit while reading part 1a"
 ```
 
 After typing that line, do not make any changes in your JSX file, and go back to webstorm, and if you type another git status, you should now see this green arrow appear.


### PR DESCRIPTION
I've noticed that the command for an empty commit in part 1a is missing a dash. 

The current command is `git commit -allow-empty -m "Practicing an empty commit while reading part 1a"`, which causes an error due to incorrect syntax.

This PR corrects the command to `git commit --allow-empty -m "Practicing an empty commit while reading part 1a"`.